### PR TITLE
fix: added separate path for browser entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "docx-templates-brandondr",
-  "version": "4.13.0-alpha",
+  "version": "4.13.1-alpha",
   "description": "Template-based docx report creation",
   "main": "lib/index.js",
+  "browser": "lib/browser.js",
   "types": "lib/index.d.ts",
   "type": "module",
   "author": "Guillermo Grau Panea",


### PR DESCRIPTION
Importing the library as is in browser fails to provide the required export. 
I am possibly missing some build process not documented in the original library.

This workaround helps make the patch work on both browser and node.
